### PR TITLE
Cannot login with POST on non www prefixed duolingo url

### DIFF
--- a/duolingo.js
+++ b/duolingo.js
@@ -43,9 +43,7 @@ var Duolingo = class Duolingo {
 		session.user_agent = Me.metadata.uuid;
 
 		var url = Constants.URL_DUOLINGO_LOGIN;
-		if (Settings.get_boolean(Constants.SETTING_SHOW_ICON_IN_NOTIFICATION_TRAY)) {
-			url = url.replace(Constants.LABEL_DUOLINGO, Constants.LABEL_DUOLINGO_WITH_WWW_PREFIX);
-		}
+		url = url.replace(Constants.LABEL_DUOLINGO, Constants.LABEL_DUOLINGO_WITH_WWW_PREFIX);
 		var params = {'login': this.login, 'password': this.password};
 		var message = Soup.form_request_new_from_hash('POST', url, params);
 		message.request_headers.append('Connection', 'keep-alive');
@@ -213,9 +211,7 @@ var Duolingo = class Duolingo {
 		session.user_agent = Me.metadata.uuid;
 
 		var url = Constants.URL_DUOLINGO_LOGIN;
-		if (Settings.get_boolean(Constants.SETTING_SHOW_ICON_IN_NOTIFICATION_TRAY)) {
-			url = url.replace(Constants.LABEL_DUOLINGO, Constants.LABEL_DUOLINGO_WITH_WWW_PREFIX);
-		}
+		url = url.replace(Constants.LABEL_DUOLINGO, Constants.LABEL_DUOLINGO_WITH_WWW_PREFIX);
 		var params = {'login': this.login, 'password': this.password};
 		var message = Soup.form_request_new_from_hash('POST', url, params);
 		message.request_headers.append('Connection', 'keep-alive');
@@ -254,9 +250,7 @@ var Duolingo = class Duolingo {
 		session.user_agent = Me.metadata.uuid;
 
 		var url = Constants.URL_DUOLINGO_LOGIN;
-		if (Settings.get_boolean(Constants.SETTING_SHOW_ICON_IN_NOTIFICATION_TRAY)) {
-			url = url.replace(Constants.LABEL_DUOLINGO, Constants.LABEL_DUOLINGO_WITH_WWW_PREFIX);
-		}
+		url = url.replace(Constants.LABEL_DUOLINGO, Constants.LABEL_DUOLINGO_WITH_WWW_PREFIX);
 		var params = {'login': this.login, 'password': this.password};
 		var message = Soup.form_request_new_from_hash('POST', url, params);
 		message.request_headers.append('Connection', 'keep-alive');


### PR DESCRIPTION
All unofficial duolingo API login to www.duolingo.com and not duolingo.com. Plus at the time being at least one cannot login with POST (form-encoded or JSON) to duolingo.com but can to www.duolingo.com. So force www.duolingo.com hostname for all login requests.