### PR TITLE
Increase size of the extension preference box

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -442,7 +442,7 @@ DuolingoStatusSettingsWidget.prototype = {
                                  'vscrollbar-policy': Gtk.PolicyType.AUTOMATIC,
                                  'hexpand': true, 'vexpand': true});
         scrollingWindow.set_child(this.vbox);
-        scrollingWindow.width_request = 400;
+        scrollingWindow.width_request = 700;
         scrollingWindow.show();
 		scrollingWindow.unparent();
 		scrollingWindow.connect('destroy', Lang.bind(this, function() {


### PR DESCRIPTION
Increase this extension preference gtkscrolledwindow size so as not to have to scroll to see the switches. 400 pixels was tiny.

This gtkscrolledwindow could be removed altogether as with GNOME Shell 42 (our minimal supported shell) there is already a GtkSCrolledWindow up in the widget chain: https://gjs.guide/extensions/upgrading/gnome-shell-42.html#gtk-scrolledwindow.
(then the prefs window will get the appropriate size per default).
Though this fix is enough for now and before removing this gtkscrolledwindow I would like to sort out the fact that the callback we attach to its destroy signal never triggers in GNOME, likely due to GTK4 behavior changes https://gitlab.gnome.org/GNOME/gtk/-/issues/3243 (though I see no leaked reference in this extension code, maybe in the gnome-extensions-app code?). Though I will not have enough time to sort this out soon or ever.